### PR TITLE
fix : 메뉴 및 약관 외부url이 바로 뜨지 않는 현상 수정

### DIFF
--- a/src/pages/MySetting/MySetting.jsx
+++ b/src/pages/MySetting/MySetting.jsx
@@ -121,8 +121,8 @@ const MySetting = () => {
           isChecked={check3}
         />
         <styled.TextDiv>
-          (필수) <a href="https://www.notion.so/kkamantokki/64f46691e1b24c11aa25daab4e3faa3d" target="_blank">이용약관</a>
-           및 <a href="https://www.notion.so/kkamantokki/2c0f24c4a6e7454b8d67e7821914688b" target="_blank">개인정보 수집 이용</a>에 동의해요.
+          (필수) <a href="https://kkamantokki.notion.site/64f46691e1b24c11aa25daab4e3faa3d" target="_blank">이용약관</a>
+           및 <a href="https://kkamantokki.notion.site/2c0f24c4a6e7454b8d67e7821914688b" target="_blank">개인정보 수집 이용</a>에 동의해요.
         </styled.TextDiv>
       </styled.CheckBoxContainer>
 

--- a/src/pages/Refrigerator/Menu.jsx
+++ b/src/pages/Refrigerator/Menu.jsx
@@ -68,8 +68,8 @@ const Menu = ({setMenuOpen}) => {
                 <MenualModal close={()=>cancelEvent('info')}/>}
                 <styled.menuButton onClick={() => returnMyRef()}><img src={myRefrigerator}/>내 냉장고로 돌아가기</styled.menuButton>
                 <styled.menuButton onClick={() => navigate('/myinfo')}><img src={riceCakeSoup}/>나의 떡국</styled.menuButton>
-                <styled.menuButton onClick={() => window.open('https://www.notion.so/kkamantokki/9597d7e1708c4bd98f184fc6da6f4a18')}><img src={question}/>자주 묻는 질문</styled.menuButton>
-                <styled.menuButton onClick={() => window.open('https://www.notion.so/kkamantokki/d8b5a61ac5e24c3eb2933efb570bf5d8')}><img src={toDeveloper}/>개발자에게 문의</styled.menuButton>
+                <styled.menuButton onClick={() => window.open('https://kkamantokki.notion.site/9597d7e1708c4bd98f184fc6da6f4a18')}><img src={question}/>자주 묻는 질문</styled.menuButton>
+                <styled.menuButton onClick={() => window.open('https://kkamantokki.notion.site/d8b5a61ac5e24c3eb2933efb570bf5d8')}><img src={toDeveloper}/>개발자에게 문의</styled.menuButton>
                 <styled.menuButton onClick={() => window.open('https://kkamantokki.notion.site/2023-836477e651e24ecb9e76db9ce210e646')}><img src={developerInfo}/>까만토끼 소개</styled.menuButton>
                 <styled.menuButton onClick={LogOut}><img src={logout}/>로그아웃</styled.menuButton>
             </styled.menuBar>


### PR DESCRIPTION
기존 : 링크 클릭 시 바로 노션 내용이 뜨지 않고 '아래 링크를 눌러 접속'이라는 화면이 뜸
현재 : 링크 클릭 시 바로 노션 내용이 뜨게끔 수정

마찬가지로 약관 부분은 테스트 못했습니다. 